### PR TITLE
Correctly type integer backed enums

### DIFF
--- a/src/Typed/Database/DatabaseConversion.php
+++ b/src/Typed/Database/DatabaseConversion.php
@@ -191,7 +191,8 @@ class DatabaseConversion
         $typescript = '';
 
         foreach ($types as $type) {
-            $typescript .= " '{$type}' |";
+            $value = is_string($type) ? "'{$type}'" : $type;
+            $typescript .= " $value |";
         }
 
         $typescript = rtrim($typescript, '|');


### PR DESCRIPTION
Suppose I have an enum on a model like this:

```php
enum Status: int
{
    case Started = 1;
    case InProgress = 2;
    case Completed = 3;
}
```

This currently generates the enums as strings, like so:

```
export interface SomeModel {
  status?: '1' | '2' | '3'
}
```

But they are really ints. Here's a patch that generates strings for strings and numbers for ints.

```
export interface SomeModel {
  status?: 1 | 2 | 3
}
```